### PR TITLE
refactor: Update Slack channel for notifications

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -177,7 +177,7 @@ jobs:
           payload-templated: true
           payload: |
             {
-              "channel": "U093TBG6FST",
+              "channel": "C09FJTNSAB0",
               "text": "Deployment Status: ${{ job.status }}",
               "blocks": [
                 {


### PR DESCRIPTION
Changed the Slack channel ID in the deploy-supabase workflow to send deployment status updates to a new channel.